### PR TITLE
Remove use of Format-Environment

### DIFF
--- a/layer/bootstrap
+++ b/layer/bootstrap
@@ -10,7 +10,6 @@ Import-Module pwsh-runtime
 
 try
 {
-    Format-Environment
     Push-Location $env:LAMBDA_TASK_ROOT
 
     Set-PSModulePath -ProjectPath $env:LAMBDA_TASK_ROOT -RuntimePath $private:runtimePath

--- a/layer/modules/pwsh-runtime/pwsh-runtime.psd1
+++ b/layer/modules/pwsh-runtime/pwsh-runtime.psd1
@@ -12,7 +12,7 @@
 RootModule = 'pwsh-runtime.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.1'
+ModuleVersion = '0.0.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -76,7 +76,6 @@ FunctionsToExport = @(
     'Get-LambdaInvocation'
     'Get-LambdaContext'
     'Publish-LambdaErrorDetails'
-    'Format-Environment'
     'Set-PSModulePath'
 )
 

--- a/layer/modules/pwsh-runtime/pwsh-runtime.psm1
+++ b/layer/modules/pwsh-runtime/pwsh-runtime.psm1
@@ -247,7 +247,7 @@ function Publish-LambdaErrorDetails
             'AWS_LAMBDA_LOG_GROUP_NAME' = $env:AWS_LAMBDA_LOG_GROUP_NAME
             'Lambda-Runtime-Aws-Request-Id' = $Header['Lambda-Runtime-Aws-Request-Id']
             'Debug' = 'false'
-            'Debug_Message' = 'Set Debug="true" as an environment variable for all environment variables, headers, and errorrecord details.'
+            'Debug_Message' = 'Set Debug="true" as an environment variable for all headers and errorrecord details.'
         }
     }
 
@@ -260,15 +260,6 @@ function Publish-LambdaErrorDetails
     Write-Verbose "Posting error to [$uri]" -Verbose
     $body | Invoke-RestMethod -Uri $uri -Method Post -Header @{
         'Lambda-Runtime-Function-Error-Type' = $lambdaError.errorType
-    }
-}
-
-function Format-Environment
-{
-    # Outputs environment variables, uses patten that could be used in powershell
-    Write-Verbose 'Environment Variables:' -Verbose
-    Get-ChildItem -Path env: | Foreach-Object {
-        Write-Output ('$env:{0} = "{1}"'-f $_.name, $_.value)
     }
 }
 


### PR DESCRIPTION
`Format-Environment` was logging all environment variables every time the lambda was executing. This had the side effect of logging the session tokens. This was removed because it was not needed any more.